### PR TITLE
Config db options not passed to Profiler

### DIFF
--- a/src/Db/Adapter/ProfilingAdapterFactory.php
+++ b/src/Db/Adapter/ProfilingAdapterFactory.php
@@ -26,8 +26,8 @@ class ProfilingAdapterFactory implements FactoryInterface
         } else {
             $adapter->setProfiler(new Profiler\Profiler());
         }
-        if (isset($dbParams['options']) && is_array($dbParams['options'])) {
-            $options = $dbParams['options'];
+        if (isset($config['db']['options']) && is_array($config['db']['options'])) {
+            $options = $config['db']['options'];
         } else {
             $options = array();
         }


### PR DESCRIPTION
there's a undefined array in __invoke(). it should be `$config['db']` instead of `$dbParams`